### PR TITLE
fix border viewsize calculation

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -320,7 +320,7 @@ void R_SetVrect (vrect_t *pvrectin, vrect_t *pvrect, int lineadj)
 		size = 100;
 		lineadj = 0;
 	}
-	size /= 100;
+	size /= 100.0;
 
 	h = pvrectin->height - lineadj;
 	pvrect->width = pvrectin->width * size;


### PR DESCRIPTION
With view size >= 100, there were a few pixels of border. 
This bug was already introduced by id software themselves in the GPL release of the source code.